### PR TITLE
Fix DLsite thumbnail URL generation for different ID formats

### DIFF
--- a/src/components/Home/ZappingGameItem.svelte
+++ b/src/components/Home/ZappingGameItem.svelte
@@ -8,12 +8,13 @@
 </script>
 
 <div
-  class="hover:scale-115 hover:shadow-md focus-within:scale-110 focus-within:shadow-md transition-all cursor-pointer w-full h-full"
+  class="hover:scale-115 hover:shadow-md focus-within:scale-110 focus-within:shadow-md transition-all cursor-pointer w-full h-full relative hover:z-10"
 >
   <a
     tabIndex={0}
     href={`/works/${collectionElement.id}?gamename=${collectionElement.gamename}`}
     use:link
+    class="block w-full h-full"
   >
     {#if collectionElement.thumbnailWidth && collectionElement.thumbnailHeight}
       <img

--- a/src/lib/scrapeAllGame.ts
+++ b/src/lib/scrapeAllGame.ts
@@ -12,8 +12,8 @@ const MAX_SCRAPE_COUNT = 20;
 const ALL_GAME_CACHE_BASE_QUERY = `SELECT id, gamename, CASE WHEN dmm_genre='digital' AND dmm_genre_2='pcgame' THEN 'https://pics.dmm.co.jp/digital/pcgame/' || dmm || '/' || dmm || 'pl.jpg'
 WHEN dmm_genre='digital' AND dmm_genre_2='doujin' THEN 'https://doujin-assets.dmm.co.jp/digital/game/' || dmm || '/' || dmm || 'pr.jpg'
 WHEN dmm_genre='mono' AND dmm_genre_2='pcgame' THEN 'https://pics.dmm.co.jp/mono/game/' || dmm || '/' || dmm || 'pl.jpg'
-WHEN dlsite_id IS NOT NULL AND (dlsite_domain='pro' OR dlsite_domain='soft') THEN 'https://img.dlsite.jp/modpub/images2/work/professional/' || left(dlsite_id,2) || LPAD(CAST(CAST(RIGHT(LEFT(dlsite_id, 5), 3) AS INTEGER) + 1 AS TEXT), 3, '0') || '000/' || dlsite_id || '_img_main.jpg'
-WHEN dlsite_id IS NOT NULL THEN 'https://img.dlsite.jp/modpub/images2/work/doujin/' || left(dlsite_id,2) || LPAD(CAST(CAST(RIGHT(LEFT(dlsite_id, 5), 3) AS INTEGER) + 1 AS TEXT), 3, '0') || '000/' || dlsite_id || '_img_main.jpg'
+WHEN dlsite_id IS NOT NULL AND (dlsite_domain='pro' OR dlsite_domain='soft') THEN 'https://img.dlsite.jp/modpub/images2/work/professional/' || left(dlsite_id,2) || LPAD(CAST(CAST(RIGHT(LEFT(dlsite_id, LENGTH(dlsite_id)-3), LENGTH(dlsite_id)-5) AS INTEGER) + 1 AS TEXT), LENGTH(dlsite_id)-5, '0') || '000/' || dlsite_id || '_img_main.jpg'
+WHEN dlsite_id IS NOT NULL THEN 'https://img.dlsite.jp/modpub/images2/work/doujin/' || left(dlsite_id,2) || LPAD(CAST(CAST(RIGHT(LEFT(dlsite_id, LENGTH(dlsite_id)-3), LENGTH(dlsite_id)-5) AS INTEGER) + 1 AS TEXT), LENGTH(dlsite_id)-5, '0') || '000/' || dlsite_id || '_img_main.jpg'
 WHEN dmm IS NOT NULL THEN 'https://pics.dmm.co.jp/mono/game/' || dmm || '/' || dmm || 'pl.jpg'
 WHEN surugaya_1 IS NOT NULL THEN 'https://www.suruga-ya.jp/database/pics/game/' || surugaya_1 || '.jpg'
 ELSE '' END AS thumbnail_url FROM gamelist`;


### PR DESCRIPTION
DLsiteのIDが異なる長さ（例：VJ01002533（たねつみの歌）, RJ01318457（プトリカ 1st.cut:The Reason She Must Perish））の場合でも正しくサムネイルURLを生成できるように修正しました。

追記
githubに慣れていないためここに追加してしまったんですが、ホームのホバーしているサムネイル画像が前面に来るように変更しました。